### PR TITLE
Adding in missing Childs() call and fixing crash bug in Execute2

### DIFF
--- a/clipper.go
+++ b/clipper.go
@@ -3673,7 +3673,7 @@ func (c *Clipper) JoinPoints(j *Join, outRec1, outRec2 *OutRec) bool {
 //returns 0 if false, +1 if true, -1 if pt ON polygon boundary
 //See "The Point in Polygon Problem for Arbitrary Polygons" by Hormann & Agathos
 //http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.88.5498&rep=rep1&type=pdf
-func (c *Clipper) PointInPolygon(pt *IntPoint, path Path) int {
+func PointInPolygon(pt *IntPoint, path Path) int {
 	result := 0
 	cnt := len(path)
 	if cnt < 3 {

--- a/clipper.go
+++ b/clipper.go
@@ -1316,6 +1316,7 @@ func (c *Clipper) Execute2(clipType ClipType,
 	succeeded = c.ExecuteInternal()
 	//build the return polygons ...
 	if succeeded {
+		polytree = NewPolyTree()
 		c.BuildResult2(polytree)
 	}
 	return

--- a/clipper.go
+++ b/clipper.go
@@ -210,9 +210,9 @@ func (pn *PolyNode) GetNextSiblingUp() *PolyNode {
 	}
 }
 
-//func (pn *PolyNode) Childs() []*PolyNode {
-//	return pn.m_Childs
-//}
+func (pn *PolyNode) Childs() []*PolyNode {
+	return pn.m_Childs
+}
 
 func (pn *PolyNode) Parent() *PolyNode {
 	return pn.m_Parent


### PR DESCRIPTION
Fixing up two small problems that prevent the use of polytrees and prevent the use of the Execute2 function.