### PR TITLE
Fix a bug in BuildResults2

### DIFF
--- a/clipper.go
+++ b/clipper.go
@@ -61,6 +61,30 @@ func NewPaths() Paths {
 	return Paths(make([]Path, 0))
 }
 
+func (p Path) Equal(q Path) bool {
+	if len(p) != len(q) {
+		return false
+	}
+	for i := 0; i < len(p); i++ {
+		if p[i].NotEqual(q[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (ps Paths) Equal(qs Paths) bool {
+	if len(ps) != len(qs) {
+		return false
+	}
+	for i := 0; i < len(ps); i++ {
+		if !ps[i].Equal(qs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (p Path) String() string {
 	v := make([]string, len(p))
 	for i, pp := range p {

--- a/clipper.go
+++ b/clipper.go
@@ -3302,7 +3302,7 @@ func (c *Clipper) BuildResult2(polytree *PolyTree) {
 	}
 
 	//fixup PolyNode links etc ...
-	polytree.m_Childs = make([]*PolyNode, len(c.m_PolyOuts))
+	polytree.m_Childs = make([]*PolyNode, 0, len(c.m_PolyOuts))
 	for i := 0; i < len(c.m_PolyOuts); i++ {
 		outRec := c.m_PolyOuts[i]
 		if outRec.PolyNode == nil {

--- a/use_int32.go
+++ b/use_int32.go
@@ -6,3 +6,5 @@ type CInt int32
 
 const loRange CInt = 46340
 const hiRange CInt = 46340
+const CIntMin = CInt(-0x80000000)
+const CIntMax = CInt(0x7FFFFFFF)

--- a/use_int64.go
+++ b/use_int64.go
@@ -6,3 +6,5 @@ type CInt int64
 
 const loRange CInt = 0x3FFFFFFF
 const hiRange CInt = 0x3FFFFFFFFFFFFFFF //L;  // it won't compile with the L there
+const CIntMin = CInt(-0x8000000000000000)
+const CIntMax = CInt(0x7FFFFFFFFFFFFFFF)


### PR DESCRIPTION
The C++ original reads
`polytree.Childs.reserve(m_PolyOuts.size());`
The equivalent go is to create a slice of zero length with a capacity of `m_PolyOuts.size()`
without this change `BuildResult2` creates an invalid polytree with additional `nil` elements at the beginning.