### PR TITLE
Fix bug in construction of polytree

### DIFF
--- a/clipper.go
+++ b/clipper.go
@@ -3302,7 +3302,7 @@ func (c *Clipper) BuildResult2(polytree *PolyTree) {
 	}
 
 	//fixup PolyNode links etc ...
-	polytree.m_Childs = make([]*PolyNode, len(c.m_PolyOuts))
+	polytree.m_Childs = make([]*PolyNode, 0, len(c.m_PolyOuts))
 	for i := 0; i < len(c.m_PolyOuts); i++ {
 		outRec := c.m_PolyOuts[i]
 		if outRec.PolyNode == nil {


### PR DESCRIPTION
The C++ original reads
`polytree.Childs.reserve(m_PolyOuts.size());`
The equivalent go is to create a slice of zero length with a capacity of `m_PolyOuts.size()`
without this change `BuildResult2` creates an invalid polytree with additional `nil` elements at the beginning.