### PR TITLE
fix ClipperOffset.Execute2 not creating a new polytree instance

### DIFF
--- a/clipper.go
+++ b/clipper.go
@@ -475,7 +475,7 @@ var horizontal = math.Inf(-1)
 const (
 	Skip       int     = -2
 	Unassigned int     = -1
-	tolerance  float64 = 1.0E-20
+	tolerance  float64 = 1.0e-20
 )
 
 type ClipperBase struct {
@@ -4732,7 +4732,7 @@ func (co *ClipperOffset) Execute(delta float64) (solution Paths) {
 //------------------------------------------------------------------------------
 
 func (co *ClipperOffset) Execute2(delta float64) (solution *PolyTree) {
-	solution.Clear()
+	solution = NewPolyTree()
 	co.FixOrientations()
 	co.DoOffset(delta)
 


### PR DESCRIPTION
This fixes an error in the ClipperOffset.Execute2 function, where solution gets never set.
It just calls  NewPolyTree() to get a new tree.