### PR TITLE
Fix branching in RangeTest

### DIFF
--- a/clipper.go
+++ b/clipper.go
@@ -622,10 +622,10 @@ func (c *ClipperBase) RangeTest(Pt *IntPoint, useFullRange *bool) {
 	if *useFullRange {
 		if Pt.X > hiRange || Pt.Y > hiRange || -Pt.X > hiRange || -Pt.Y > hiRange {
 			panic(NewClipperException("Coordinate outside allowed range"))
-		} else if Pt.X > loRange || Pt.Y > loRange || -Pt.X > loRange || -Pt.Y > loRange {
-			*useFullRange = true
-			c.RangeTest(Pt, useFullRange)
 		}
+	} else if Pt.X > loRange || Pt.Y > loRange || -Pt.X > loRange || -Pt.Y > loRange {
+		*useFullRange = true
+		c.RangeTest(Pt, useFullRange)
 	}
 }
 


### PR DESCRIPTION
While investigating #16, I saw that this branching seems incorrect when compared to the original versions and the JavaScript port.

I personally didn't run into any problem caused by this, but it might be a good idea to patch 🙂 

For reference:
- https://sourceforge.net/p/polyclipping/code/HEAD/tree/tags/6.2.0/C%23/clipper_library/clipper.cs
- https://sourceforge.net/p/polyclipping/code/HEAD/tree/tags/6.2.0/Delphi/clipper.pas
- https://sourceforge.net/p/polyclipping/code/HEAD/tree/tags/6.2.0/cpp/clipper.cpp