### PR TITLE
Fix Y-sorting of intersection list

### DIFF
--- a/clipper.go
+++ b/clipper.go
@@ -385,7 +385,7 @@ func (in *IntersectNode) String() string {
 type IntersectNodeList []*IntersectNode
 
 func (i IntersectNodeList) Len() int           { return len(i) }
-func (i IntersectNodeList) Less(a, b int) bool { return i[a].Pt.Y < i[b].Pt.Y }
+func (i IntersectNodeList) Less(a, b int) bool { return i[a].Pt.Y > i[b].Pt.Y }
 func (i IntersectNodeList) Swap(a, b int)      { i[a], i[b] = i[b], i[a] }
 
 //  class MyIntersectNodeSort : IComparer<IntersectNode>

--- a/clipper_test.go
+++ b/clipper_test.go
@@ -177,3 +177,53 @@ func TestExecute1(t *testing.T) {
 		}
 	}
 }
+
+var testCasesPftNonZero = []testCase{
+	{
+		subj: Paths{
+			{
+				{X: 53000000000, Y: 180000000000},
+				{X: 68000000000, Y: 200000000000},
+				{X: 44000000000, Y: 199000000000},
+			},
+			{
+				{X: 65000000000, Y: 160000000000},
+				{X: 58000000000, Y: 189000000000},
+				{X: 30000000000, Y: 190000000000},
+			},
+			{
+				{X: 61000000000, Y: 189000000000},
+				{X: 52000000000, Y: 195000000000},
+				{X: 48000000000, Y: 187000000000},
+			},
+		},
+		clip: Paths{},
+		solutions: []Paths{
+			// union
+			{{{58426086957, 187234782609}, {59586956522, 188782608696}, {X: 61000000000, Y: 189000000000}, {X: 60166666667, Y: 189555555556}, {X: 68000000000, Y: 200000000000}, {X: 44000000000, Y: 199000000000}, {X: 48577437859, Y: 189336520076}, {X: 30000000000, Y: 190000000000}, {X: 65000000000, Y: 160000000000}}},
+		},
+	},
+}
+
+func TestExecute1_Union_PftNonZero(t *testing.T) {
+	for i, v := range testCasesPftNonZero {
+		testName := fmt.Sprintf("fix%03d", i)
+		c := NewClipper(IoNone)
+		pft := PftNonZero
+
+		clipName := []string{"union"}
+		clipTypes := []ClipType{CtUnion}
+		c.AddPaths(v.subj, PtSubject, true)
+		c.AddPaths(v.clip, PtClip, true)
+
+		for j, ct := range clipTypes {
+			solution, ok := c.Execute1(ct, pft, pft)
+			if !ok {
+				t.Errorf("error running Execute1 %v: ok=false", clipName[j])
+			}
+			if got, want := solution.String(), v.solutions[j].String(); got != want {
+				t.Errorf("bad %v %v solution, got=%v, want=%v", testName, clipName[j], got, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #16 

## Description

There seems to be some confusion about how the literature states this and how Clipper was implemented.

http://what-when-how.com/computer-graphics-and-geometric-modeling/clipping-basic-computer-graphics-part-5/ states:

> an intersection list (IL) to identify and store all the intersections in the current scan beam (...). It is sorted in an increasing order by the y-coordinate of the intersection

It seems that Clipper works with decreasing order, though. The Go Clipper implementation uses increasing order and that is what caused the bug in #16.

## Reference lib vs Current Go Clipper

We can see in the [C# implementation](https://sourceforge.net/p/polyclipping/code/HEAD/tree/tags/6.2.0/C%23/clipper_library/clipper.cs) that the order is indeed decreasing:
```c#
  public class MyIntersectNodeSort : IComparer<IntersectNode>
  {
    public int Compare(IntersectNode node1, IntersectNode node2)
    {
      cInt i = node2.Pt.Y - node1.Pt.Y;
      if (i > 0) return 1;
      else if (i < 0) return -1;
      else return 0;
    }
  }
```

This implementation returns `1` if the `node2.Pt.Y` is greater than `node1.Pt.Y`, and returning `1` puts `node2` before `node1` (thus the largest Y to the front, descending order).

The current implementation for Go Clipper has:
```go
func (i IntersectNodeList) Less(a, b int) bool { return i[a].Pt.Y < i[b].Pt.Y }
```

Which returns `true` if `i[a].Pt.Y` is smaller. This promotes an increasing order, so changing to return `true` if `i[a].Pt.Y` is larger gives us the decreasing order.

## Results

The test case is performing an union between these 3 triangles:

![image](https://user-images.githubusercontent.com/4842605/117076732-49d7ed80-ad0d-11eb-8b0d-23de35cb0866.png)

the bug will happen in this part:

![image](https://user-images.githubusercontent.com/4842605/117076812-70962400-ad0d-11eb-8b48-ff703c7ef127.png)

Without the fix, that part results in (which is incorrect):

![image](https://user-images.githubusercontent.com/4842605/117076865-8572b780-ad0d-11eb-9ea3-bd9bee9d15e6.png)

With the fix, it is correct:

![image](https://user-images.githubusercontent.com/4842605/117077008-bf43be00-ad0d-11eb-976a-b92dfb9a87a8.png)
