### PR TITLE
Fix deviation to cpp version

### DIFF
--- a/clipper.go
+++ b/clipper.go
@@ -1755,9 +1755,9 @@ func (c *Clipper) SetWindingCount(edge *TEdge) {
 			//so we're inside the previous polygon ...
 			if edge.WindDelta == 0 {
 				if e.WindCnt < 0 {
-					e.WindCnt = e.WindCnt - 1
+					edge.WindCnt = e.WindCnt - 1
 				} else {
-					e.WindCnt = e.WindCnt + 1
+					edge.WindCnt = e.WindCnt + 1
 				}
 				//if wind direction is reversing prev then use same WC
 			} else if e.WindDelta*edge.WindDelta < 0 {


### PR DESCRIPTION
In the 6.1.3 and 6.2.0 (I couldn't find version 6.1.5 on sourceforge) cpp version of the clipper lib there is a deviation to the code here in the `SetWindingCount` function: 

![grafik](https://user-images.githubusercontent.com/38033710/136032179-cfd2a09b-baa6-40b5-a6bc-8710476d95aa.png)

This PR fixes the deviation to reflect the cpp version.